### PR TITLE
Fix to separate filter items by a ; instead of a ,

### DIFF
--- a/src/main/java/com/smartystreets/api/us_autocomplete/Client.java
+++ b/src/main/java/com/smartystreets/api/us_autocomplete/Client.java
@@ -1,7 +1,10 @@
 package com.smartystreets.api.us_autocomplete;
 
 
-import com.smartystreets.api.*;
+import com.smartystreets.api.Request;
+import com.smartystreets.api.Response;
+import com.smartystreets.api.Sender;
+import com.smartystreets.api.Serializer;
 import com.smartystreets.api.exceptions.SmartyException;
 
 import java.io.IOException;
@@ -9,7 +12,7 @@ import java.util.ArrayList;
 
 /**
  * This client sends lookups to the SmartyStreets US Autocomplete API, <br>
- *     and attaches the results to the appropriate Lookup objects.
+ * and attaches the results to the appropriate Lookup objects.
  */
 public class Client {
     private final Sender sender;
@@ -47,8 +50,7 @@ public class Client {
         if (lookup.getGeolocateType() != GeolocateType.NONE) {
             request.putParameter("geolocate", "true");
             request.putParameter("geolocate_precision", lookup.getGeolocateType().getName());
-        }
-        else request.putParameter("geolocate", "false");
+        } else request.putParameter("geolocate", "false");
 
         return request;
     }
@@ -60,11 +62,11 @@ public class Client {
         String filterList = "";
 
         for (String item : list) {
-            filterList += (item + ",");
+            filterList += (item + ";");
         }
 
-        if (filterList.endsWith(","))
-            filterList = filterList.substring(0, filterList.length()-1);
+        if (filterList.endsWith(";"))
+            filterList = filterList.substring(0, filterList.length() - 1);
 
         return filterList;
     }

--- a/src/main/java/com/smartystreets/api/us_autocomplete/Client.java
+++ b/src/main/java/com/smartystreets/api/us_autocomplete/Client.java
@@ -42,7 +42,7 @@ public class Client {
         request.putParameter("suggestions", lookup.getMaxSuggestionsStringIfSet());
         request.putParameter("city_filter", this.buildFilterString(lookup.getCityFilter()));
         request.putParameter("state_filter", this.buildFilterString(lookup.getStateFilter()));
-        request.putParameter("prefer", this.buildFilterString(lookup.getPrefer()));
+        request.putParameter("prefer", this.buildPreferString(lookup.getPrefer()));
         request.putParameter("prefer_ratio", lookup.getPreferRatioStringIfSet());
         if (lookup.getGeolocateType() != GeolocateType.NONE) {
             request.putParameter("geolocate", "true");
@@ -53,17 +53,25 @@ public class Client {
         return request;
     }
 
+    private String buildPreferString(ArrayList<String> list) {
+        return buildStringFromList(list, ";");
+    }
+
     private String buildFilterString(ArrayList<String> list) {
+        return buildStringFromList(list, ",");
+    }
+
+    private String buildStringFromList(ArrayList<String> list, String separator) {
         if (list.isEmpty())
             return null;
 
         String filterList = "";
 
         for (String item : list) {
-            filterList += (item + ",");
+            filterList += (item + separator);
         }
 
-        if (filterList.endsWith(","))
+        if (filterList.endsWith(separator))
             filterList = filterList.substring(0, filterList.length()-1);
 
         return filterList;

--- a/src/main/java/com/smartystreets/api/us_autocomplete/Client.java
+++ b/src/main/java/com/smartystreets/api/us_autocomplete/Client.java
@@ -1,10 +1,7 @@
 package com.smartystreets.api.us_autocomplete;
 
 
-import com.smartystreets.api.Request;
-import com.smartystreets.api.Response;
-import com.smartystreets.api.Sender;
-import com.smartystreets.api.Serializer;
+import com.smartystreets.api.*;
 import com.smartystreets.api.exceptions.SmartyException;
 
 import java.io.IOException;
@@ -12,7 +9,7 @@ import java.util.ArrayList;
 
 /**
  * This client sends lookups to the SmartyStreets US Autocomplete API, <br>
- * and attaches the results to the appropriate Lookup objects.
+ *     and attaches the results to the appropriate Lookup objects.
  */
 public class Client {
     private final Sender sender;
@@ -50,7 +47,8 @@ public class Client {
         if (lookup.getGeolocateType() != GeolocateType.NONE) {
             request.putParameter("geolocate", "true");
             request.putParameter("geolocate_precision", lookup.getGeolocateType().getName());
-        } else request.putParameter("geolocate", "false");
+        }
+        else request.putParameter("geolocate", "false");
 
         return request;
     }
@@ -62,11 +60,11 @@ public class Client {
         String filterList = "";
 
         for (String item : list) {
-            filterList += (item + ";");
+            filterList += (item + ",");
         }
 
-        if (filterList.endsWith(";"))
-            filterList = filterList.substring(0, filterList.length() - 1);
+        if (filterList.endsWith(","))
+            filterList = filterList.substring(0, filterList.length()-1);
 
         return filterList;
     }


### PR DESCRIPTION
Based on the behavior of testing, it seems the end point requires filter items to be separated by a ';' instead of a ',' but the SDK uses a ',' for separation. The patch here should address that.