### PR TITLE
feature: add EmbeddedKeyCredentials request signer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ You may have noticed this page is curiously sparse. Don't panic, there's [docume
 
 When using this library in an Android project, be sure to exclude commons-logging and httpclient as they will conflict with classes provided by Android.
 
+If you use an embedded key on the server-side (for US Autocomplete Pro for example), 
+you should whitelist your server IP and use `EmbeddedKeyCredentials` instead of `SharedCredentials`.
+
 [Apache 2.0 License](src/main/resources/LICENSE.txt)
 
 ---

--- a/src/main/java/com/smartystreets/api/EmbeddedKeyCredentials.java
+++ b/src/main/java/com/smartystreets/api/EmbeddedKeyCredentials.java
@@ -1,0 +1,16 @@
+package com.smartystreets.api;
+
+/**
+ * EmbeddedKeyCredentials is useful if you want to use a website key without specifying a hostname.
+ */
+public class EmbeddedKeyCredentials implements Credentials {
+    private final String id;
+
+    public EmbeddedKeyCredentials(String id) {
+        this.id = id;
+    }
+
+    public void sign(Request request) {
+        request.putParameter("key", this.id);
+    }
+}

--- a/src/test/java/com/smartystreets/api/EmbeddedKeyCredentialsTest.java
+++ b/src/test/java/com/smartystreets/api/EmbeddedKeyCredentialsTest.java
@@ -1,0 +1,25 @@
+package com.smartystreets.api;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class EmbeddedKeyCredentialsTest {
+    @Test
+    public void assertSignedRequest() {
+        Request request = this.createSignedRequest();
+        String expected = "https://us-street.api.smartystreets.com/street-address?key=3516378604772256";
+
+        assertEquals("Request param 'key' must be specified", expected, request.getUrl());
+	    assertNull("Request header 'Referer' must not be specified", request.getHeaders().get("Referer"));
+    }
+
+    private Request createSignedRequest() {
+        Credentials credentials = new EmbeddedKeyCredentials("3516378604772256");
+        Request request = new Request();
+        request.setUrlPrefix("https://us-street.api.smartystreets.com/street-address");
+        credentials.sign(request);
+        return request;
+    }
+}


### PR DESCRIPTION
Hi!
I propose to add a class that will add to request embedded key (aka website key) without hostname.

Use case:
> I want to use US Autocomplete Pro on my server. This API doesn't support server keys, so I need to use an embedded key instead. But SmartyStreets have security rate limits for embedded keys, so one IP cannot spam requests. Documentation advises whitelist IP to bypass security limits. But SmartyStreets looks at hostname instead of IP if it specified (saw that on practice), so I should specify server IP in the hostname or just don't specify a hostname. 