### PR TITLE
Fixes for prefer_ratio in US Autocomplete Pro API

### DIFF
--- a/src/main/java/com/smartystreets/api/us_autocomplete_pro/Lookup.java
+++ b/src/main/java/com/smartystreets/api/us_autocomplete_pro/Lookup.java
@@ -103,14 +103,14 @@ public class Lookup {
 
     public List<String> getPreferZipcode() { return this.preferZipcode; }
 
-    public double getPreferRatio() {
+    public int getPreferRatio() {
         return this.preferRatio;
     }
 
     String getPreferRatioStringIfSet() {
         if (this.preferRatio == this.PREFER_RATIO_DEFAULT)
             return null;
-        return Double.toString(this.preferRatio);
+        return Integer.toString(this.preferRatio);
     }
 
     public GeolocateType getGeolocateType() {

--- a/src/main/java/com/smartystreets/api/us_autocomplete_pro/Lookup.java
+++ b/src/main/java/com/smartystreets/api/us_autocomplete_pro/Lookup.java
@@ -11,7 +11,7 @@ import java.util.List;
  *     @see "https://smartystreets.com/docs/cloud/us-autocomplete-api#http-request-input-fields"
  */
 public class Lookup {
-    final int PREFER_RATIO_DEFAULT = 33;
+    final int PREFER_RATIO_DEFAULT = 100;
     final int MAX_SUGGESTIONS_DEFAULT = 10;
 
     //region [ Fields ]

--- a/src/test/java/com/smartystreets/api/us_autocomplete_pro/ClientTest.java
+++ b/src/test/java/com/smartystreets/api/us_autocomplete_pro/ClientTest.java
@@ -33,7 +33,7 @@ public class ClientTest {
         URLPrefixSender sender = new URLPrefixSender("http://localhost/", capturingSender);
         FakeSerializer serializer = new FakeSerializer(new Result());
         Client client = new Client(sender, serializer);
-        String expectedURL = "http://localhost/?search=1&max_results=2&include_only_cities=3&include_only_states=4&prefer_ratio=60.0&prefer_geolocation=state";
+        String expectedURL = "http://localhost/?search=1&max_results=2&include_only_cities=3&include_only_states=4&prefer_ratio=60&prefer_geolocation=state";
         Lookup lookup = new Lookup();
         lookup.setSearch("1");
         lookup.setMaxSuggestions(2);


### PR DESCRIPTION
The US Autocomplete Pro API requires `prefer_ratio` to be sent as an int, or it returns HTTP status 422. Currently it is being sent as a double with a superfluous `.0`.
Also, the API spec indicates the default is 100, not 33. When the ratio matches the default it doesn't send the field's value, so a value of 33 would result in an effective value of 100.