### PR TITLE
Add urlComponents field to request

### DIFF
--- a/src/main/java/com/smartystreets/api/Request.java
+++ b/src/main/java/com/smartystreets/api/Request.java
@@ -11,11 +11,13 @@ public class Request {
     private final Map<String, String> parameters;
     private String urlPrefix;
     private String method;
+    private String urlComponents;
     private String contentType;
     private byte[] payload;
 
     public Request() {
         this.urlPrefix = "";
+        this.urlComponents = "";
         this.method = "GET";
         this.headers = new HashMap<>();
         this.parameters = new LinkedHashMap<>();
@@ -75,10 +77,6 @@ public class Request {
         return this.payload;
     }
 
-    public String getUrlPrefix()  {
-        return this.urlPrefix;
-    }
-
     public String getContentType() {
         return contentType;
     }
@@ -93,7 +91,11 @@ public class Request {
     }
 
     public void setUrlPrefix(String urlPrefix) {
-        this.urlPrefix = urlPrefix;
+        this.urlPrefix = urlPrefix + urlComponents;
+    }
+
+    public void setUrlComponents(String urlComponents) {
+        this.urlComponents = urlComponents;
     }
 
     public void setContentType(String contentType) {

--- a/src/main/java/com/smartystreets/api/URLPrefixSender.java
+++ b/src/main/java/com/smartystreets/api/URLPrefixSender.java
@@ -15,11 +15,8 @@ public class URLPrefixSender implements Sender{
     }
 
     public Response send(Request request) throws IOException, SmartyException, InterruptedException {
-        if(request.getUrlPrefix() != null && !request.getUrlPrefix().isEmpty()) {
-            request.setUrlPrefix(this.urlPrefix + request.getUrlPrefix());
-        } else {
-            request.setUrlPrefix(this.urlPrefix);
-        }
+        request.setUrlPrefix(this.urlPrefix);
+
         return this.inner.send(request);
     }
 }

--- a/src/main/java/com/smartystreets/api/international_autocomplete/Client.java
+++ b/src/main/java/com/smartystreets/api/international_autocomplete/Client.java
@@ -38,7 +38,7 @@ public class Client {
         Request request = new Request();
 
         if(lookup.getAddressID() != null && !lookup.getAddressID().isEmpty()) {
-            request.setUrlPrefix("/" + lookup.getAddressID());
+            request.setUrlComponents("/" + lookup.getAddressID());
         }
 
         request.putParameter("country", lookup.getCountry());

--- a/src/main/java/com/smartystreets/api/us_enrichment/Client.java
+++ b/src/main/java/com/smartystreets/api/us_enrichment/Client.java
@@ -46,7 +46,7 @@ public class Client {
 
     private Request buildRequest(Lookup lookup) {
         Request request = new Request();
-        request.setUrlPrefix("/" + lookup.getSmartyKey() + "/" + lookup.getDatasetName() + "/" + lookup.getDataSubsetName());
+        request.setUrlComponents("/" + lookup.getSmartyKey() + "/" + lookup.getDatasetName() + "/" + lookup.getDataSubsetName());
         return request;
     }
 }

--- a/src/main/java/examples/UsStreetSingleAddressExample.java
+++ b/src/main/java/examples/UsStreetSingleAddressExample.java
@@ -15,7 +15,7 @@ public class UsStreetSingleAddressExample {
     public static void main(String[] args) {
         // We recommend storing your authentication credentials in environment variables.
         // for server-to-server requests, use this code:
-        //StaticCredentials credentials = new StaticCredentials(System.getenv("SMARTY_AUTH_ID"), System.getenv("SMARTY_AUTH_TOKEN"));
+        // StaticCredentials credentials = new StaticCredentials(System.getenv("SMARTY_AUTH_ID"), System.getenv("SMARTY_AUTH_TOKEN"));
 
         // for client-side requests (browser/mobile), use this code:
         SharedCredentials credentials = new SharedCredentials(System.getenv("SMARTY_AUTH_WEB"), System.getenv("SMARTY_AUTH_REFERER"));

--- a/src/test/java/com/smartystreets/api/URLPrefixSenderTest.java
+++ b/src/test/java/com/smartystreets/api/URLPrefixSenderTest.java
@@ -11,7 +11,7 @@ public class URLPrefixSenderTest {
     @Test
     public void testRequestURLPresent() throws Exception {
         Request request = new Request();
-        request.setUrlPrefix("/jimbo");
+        request.setUrlComponents("/jimbo");
         Sender inner = new MockSender(new Response(123, null));
         Sender sender = new URLPrefixSender("http://mysite.com/lookup", inner);
 
@@ -29,5 +29,19 @@ public class URLPrefixSenderTest {
         Response response = sender.send(request);
 
         assertEquals("http://mysite.com/lookup?", request.getUrl());       
+    }
+
+    @Test
+    public void testMultipleSends() throws Exception {
+        Request request = new Request();
+        request.setUrlComponents("/jimbo");
+        Sender inner = new MockSender(new Response(123, null));
+        Sender sender = new URLPrefixSender("http://mysite.com/lookup", inner);
+
+        Response response = sender.send(request);
+        response = sender.send(request);
+        response = sender.send(request);
+
+        assertEquals("http://mysite.com/lookup/jimbo?", request.getUrl());              
     }
 }


### PR DESCRIPTION
Resolves #45 

- Build the urlPrefix for each Request in the Request class itself
- Add a urlComponents field to Request
- Add tests to cover failing case of sending a request multiple times that had a custom urlPrefix
