### PR TITLE
Added a maxWaitTime check in the RetrySender

### DIFF
--- a/src/main/java/com/smartystreets/api/RetrySender.java
+++ b/src/main/java/com/smartystreets/api/RetrySender.java
@@ -26,6 +26,7 @@ public class RetrySender implements Sender {
     }
 
     public Response send(Request request) throws SmartyException, IOException, InterruptedException {
+        int totalWaitTime = 0;
         for (int i = 0; i <= this.maxRetries; i++) {
             Response response = this.trySend(request, i);
             if (response instanceof TooManyRequestsResponse) {
@@ -37,8 +38,9 @@ public class RetrySender implements Sender {
                 if (wait < 1) {
                     wait = 1L;
                 }
-                if (maxWaitTime > 0 && wait > maxWaitTime) {
-                    throw new SmartyException("In RetrySender, the wait time is longer than your maxWaitTime.");
+                totalWaitTime += wait;
+                if (maxWaitTime > 0 && totalWaitTime > maxWaitTime) {
+                    throw new SmartyException("In RetrySender, the wait time is longer than the maxWaitTime.");
                 }
                 //this.logger.log("The rate limit for requests has been exceeded. Sleeping " + wait + " seconds...");
                 this.sleeper.sleep(wait);

--- a/src/test/java/com/smartystreets/api/RetrySenderTest.java
+++ b/src/test/java/com/smartystreets/api/RetrySenderTest.java
@@ -65,7 +65,17 @@ public class RetrySenderTest {
 
     @Test 
     public void testWaitLongerThanMaxWaitTime() throws Exception {
-        assertThrows(SmartyException.class, () -> this.sendRequest("WaitTimeTooLong", 3));
+        // The maxWaitTime is less than the total wait time of the sendRequest
+        assertThrows(SmartyException.class, () -> this.sendRequest("WaitTimeTooLong", 7));
+        assertEquals(2, this.mockCrashingSender.getSendCount());
+
+        // // The maxWaitTime is negative so it is ignored
+        this.sendRequest("WaitTimeTooLong", -1);
+        assertEquals(3, this.mockCrashingSender.getSendCount());
+
+        // The maxWaitTime is larger than the total wait time, no exception thrown
+        this.sendRequest("WaitTimeTooLong", 9);
+        assertEquals(4, this.mockCrashingSender.getSendCount());
     }
 
     private void sendRequest(String requestBehavior) throws Exception {

--- a/src/test/java/com/smartystreets/api/RetrySenderTest.java
+++ b/src/test/java/com/smartystreets/api/RetrySenderTest.java
@@ -1,5 +1,6 @@
 package com.smartystreets.api;
 
+import com.smartystreets.api.exceptions.SmartyException;
 import com.smartystreets.api.mocks.FakeLogger;
 import com.smartystreets.api.mocks.FakeSleeper;
 import com.smartystreets.api.mocks.MockCrashingSender;
@@ -62,10 +63,25 @@ public class RetrySenderTest {
         assertArrayEquals(expectedDurations, this.fakeSleeper.getSleepDurations().toArray());
     }
 
+    @Test 
+    public void testWaitLongerThanMaxWaitTime() throws Exception {
+        assertThrows(SmartyException.class, () -> this.sendRequest("WaitTimeTooLong", 3));
+    }
+
     private void sendRequest(String requestBehavior) throws Exception {
         Request request = new Request();
         request.setUrlPrefix(requestBehavior);
         RetrySender retrySender = new RetrySender(15, this.fakeSleeper, this.fakeLogger, this.mockCrashingSender);
+
+        retrySender.send(request);
+    }
+
+    private void sendRequest(String requestBehavior, long maxWaitTime) throws Exception {
+        Request request = new Request();
+        request.setUrlPrefix(requestBehavior);
+        RetrySender retrySender = new RetrySender(15, this.fakeSleeper, this.fakeLogger, this.mockCrashingSender);
+
+        retrySender.WithMaxWaitTime(maxWaitTime);
 
         retrySender.send(request);
     }

--- a/src/test/java/com/smartystreets/api/mocks/MockCrashingSender.java
+++ b/src/test/java/com/smartystreets/api/mocks/MockCrashingSender.java
@@ -40,6 +40,10 @@ public class MockCrashingSender implements Sender {
                 throw new IOException("You need to retry");
         }
 
+        if (request.getUrl().contains("WaitTimeTooLong") ) {
+            response = new TooManyRequestsResponse(Headers.of("Retry-After", "4"), STATUS_CODE, new byte[]{});
+        }
+
         return response;
     }
 

--- a/src/test/java/com/smartystreets/api/mocks/MockCrashingSender.java
+++ b/src/test/java/com/smartystreets/api/mocks/MockCrashingSender.java
@@ -41,7 +41,9 @@ public class MockCrashingSender implements Sender {
         }
 
         if (request.getUrl().contains("WaitTimeTooLong") ) {
-            response = new TooManyRequestsResponse(Headers.of("Retry-After", "4"), STATUS_CODE, new byte[]{});
+            if (this.sendCount <= 2) {
+                response = new TooManyRequestsResponse(Headers.of("Retry-After", "4"), STATUS_CODE, new byte[]{});
+            }
         }
 
         return response;


### PR DESCRIPTION
In RetrySender, the maxWaitTime is defaulted to be 0. If users choose to set the variable, it is compared with the wait time after getting a TooManyRequestsResponse to see if the wait time > maxWaitTime. If it is, it throws a SmartyException.