### PR TITLE
Add proguard rules for android. The rules file is bundled in the JAR …

### DIFF
--- a/src/main/resources/META-INF/proguard/smartystreets-java-sdk.pro
+++ b/src/main/resources/META-INF/proguard/smartystreets-java-sdk.pro
@@ -1,0 +1,7 @@
+# SmartyStreets Java SDK - ProGuard/R8 rules
+# Preserve all SDK classes for Jackson deserialization on Android.
+# Jackson uses reflection to instantiate model classes and access fields/getters.
+# R8 obfuscation breaks this without these rules.
+
+-keep class com.smartystreets.api.** { *; }
+-keepattributes *Annotation*


### PR DESCRIPTION
…at META-INF/proguard/smartystreets-java-sdk.pro. Android build tools automatically consume rules from this path, so users no longer need to manually add -keep rules for the

  SDK.

refs #53 