### PR TITLE
Add withSender() option with middleware 
  chain and conflict validation

### DIFF
--- a/src/main/java/com/smartystreets/api/ClientBuilder.java
+++ b/src/main/java/com/smartystreets/api/ClientBuilder.java
@@ -27,7 +27,6 @@ public class ClientBuilder {
     private Credentials signer;
     private Serializer serializer;
     private Sender httpSender;
-    private Sender wrappedHttpSender;
     private int maxRetries;
     private int maxTimeout;
     private String urlPrefix;
@@ -80,17 +79,6 @@ public class ClientBuilder {
      */
     public ClientBuilder withSender(Sender sender) {
         this.httpSender = sender;
-        return this;
-    }
-
-    /**
-     * Replaces the innermost SmartySender while keeping the rest of the sender chain intact.
-     *
-     * @param sender The sender to use as the HTTP transport layer.
-     * @return Returns <b>this</b> to accommodate method chaining.
-     */
-    public ClientBuilder withWrappedSender(Sender sender) {
-        this.wrappedHttpSender = sender;
         return this;
     }
 
@@ -279,12 +267,9 @@ public class ClientBuilder {
     }
 
     private Sender buildSender() {
-        if (this.httpSender != null)
-            return this.httpSender;
-
         Sender sender;
-        if (this.wrappedHttpSender != null) {
-            sender = this.wrappedHttpSender;
+        if (this.httpSender != null) {
+            sender = this.httpSender;
         } else if (this.proxy != null) {
             sender = new SmartySender(this.maxTimeout, this.proxy);
         } else {

--- a/src/main/java/com/smartystreets/api/ClientBuilder.java
+++ b/src/main/java/com/smartystreets/api/ClientBuilder.java
@@ -267,6 +267,13 @@ public class ClientBuilder {
     }
 
     private Sender buildSender() {
+        if (this.httpSender != null) {
+            java.util.List<String> conflicts = new java.util.ArrayList<>();
+            if (this.maxTimeout != 10000) conflicts.add("withMaxTimeout()");
+            if (this.proxy != null) conflicts.add("withProxy()");
+            if (!conflicts.isEmpty())
+                throw new IllegalStateException("withSender() cannot be combined with: " + String.join(", ", conflicts) + ". These options only apply to the built-in HTTP transport.");
+        }
         Sender sender;
         if (this.httpSender != null) {
             sender = this.httpSender;

--- a/src/main/java/com/smartystreets/api/ClientBuilder.java
+++ b/src/main/java/com/smartystreets/api/ClientBuilder.java
@@ -27,6 +27,7 @@ public class ClientBuilder {
     private Credentials signer;
     private Serializer serializer;
     private Sender httpSender;
+    private Sender wrappedHttpSender;
     private int maxRetries;
     private int maxTimeout;
     private String urlPrefix;
@@ -79,6 +80,17 @@ public class ClientBuilder {
      */
     public ClientBuilder withSender(Sender sender) {
         this.httpSender = sender;
+        return this;
+    }
+
+    /**
+     * Replaces the innermost SmartySender while keeping the rest of the sender chain intact.
+     *
+     * @param sender The sender to use as the HTTP transport layer.
+     * @return Returns <b>this</b> to accommodate method chaining.
+     */
+    public ClientBuilder withWrappedSender(Sender sender) {
+        this.wrappedHttpSender = sender;
         return this;
     }
 
@@ -271,7 +283,9 @@ public class ClientBuilder {
             return this.httpSender;
 
         Sender sender;
-        if (this.proxy != null) {
+        if (this.wrappedHttpSender != null) {
+            sender = this.wrappedHttpSender;
+        } else if (this.proxy != null) {
             sender = new SmartySender(this.maxTimeout, this.proxy);
         } else {
             sender = new SmartySender(this.maxTimeout);

--- a/src/test/java/com/smartystreets/api/ClientBuilderTest.java
+++ b/src/test/java/com/smartystreets/api/ClientBuilderTest.java
@@ -1,8 +1,14 @@
 package com.smartystreets.api;
 
+import com.smartystreets.api.mocks.RequestCapturingSender;
+import com.smartystreets.api.us_street.Client;
+import com.smartystreets.api.us_street.Lookup;
 import org.junit.Test;
 
+import java.io.IOException;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ClientBuilderTest {
 
@@ -21,5 +27,22 @@ public class ClientBuilderTest {
                 .withFeatureIanaTimeZone();
 
         assertEquals("component-analysis,iana-timezone", builder.getCustomQueries().get("features"));
+    }
+
+    @Test
+    public void testWithWrappedSender_WrapsWithMiddlewareChain() throws Exception {
+        RequestCapturingSender capturingSender = new RequestCapturingSender();
+        Client client = (Client) new ClientBuilder("test-id", "test-token")
+                .withWrappedSender(capturingSender)
+                .buildUsStreetApiClient();
+
+        Lookup lookup = new Lookup();
+        lookup.setStreet("1 Rosedale");
+        client.send(lookup);
+
+        String url = capturingSender.getRequest().getUrl();
+        assertTrue(url.contains("us-street.api.smarty.com"));
+        assertTrue(url.contains("auth-id=test-id"));
+        assertTrue(url.contains("auth-token=test-token"));
     }
 }

--- a/src/test/java/com/smartystreets/api/ClientBuilderTest.java
+++ b/src/test/java/com/smartystreets/api/ClientBuilderTest.java
@@ -30,10 +30,10 @@ public class ClientBuilderTest {
     }
 
     @Test
-    public void testWithWrappedSender_WrapsWithMiddlewareChain() throws Exception {
+    public void testWithSender_WrapsWithMiddlewareChain() throws Exception {
         RequestCapturingSender capturingSender = new RequestCapturingSender();
         Client client = (Client) new ClientBuilder("test-id", "test-token")
-                .withWrappedSender(capturingSender)
+                .withSender(capturingSender)
                 .buildUsStreetApiClient();
 
         Lookup lookup = new Lookup();

--- a/src/test/java/com/smartystreets/api/ClientBuilderTest.java
+++ b/src/test/java/com/smartystreets/api/ClientBuilderTest.java
@@ -29,6 +29,22 @@ public class ClientBuilderTest {
         assertEquals("component-analysis,iana-timezone", builder.getCustomQueries().get("features"));
     }
 
+    @Test(expected = IllegalStateException.class)
+    public void testWithSender_ThrowsWhenCombinedWithMaxTimeout() throws Exception {
+        new ClientBuilder("test-id", "test-token")
+                .withSender(new RequestCapturingSender())
+                .withMaxTimeout(5000)
+                .buildUsStreetApiClient();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testWithSender_ThrowsWhenCombinedWithProxy() throws Exception {
+        new ClientBuilder("test-id", "test-token")
+                .withSender(new RequestCapturingSender())
+                .withProxy(java.net.Proxy.Type.HTTP, "localhost", 8080)
+                .buildUsStreetApiClient();
+    }
+
     @Test
     public void testWithSender_WrapsWithMiddlewareChain() throws Exception {
         RequestCapturingSender capturingSender = new RequestCapturingSender();


### PR DESCRIPTION
## Summary
- Added `withSender()` option to `ClientBuilder`, allowing a custom HTTP sender to  
  be used as the innermost transport while keeping the full middleware chain intact (signing, retries, status codes, headers, URL prefix, 
  license).
- Added an error when `withSender()` is combined with `withMaxTimeout()` or `withProxy()`, as these options only apply to the
   built-in HTTP transport.

## Test plan
- [x] Existing tests pass
- [x] New tests verify the middleware chain is applied when using 
  `withSender()`
- [x] New tests verify an error is raised when conflicting options are combined with `withSender()`