### PR TITLE
Surface API error messages and standardize HTTP status fallback messages

### DIFF
--- a/src/main/java/com/smartystreets/api/SmartySerializer.java
+++ b/src/main/java/com/smartystreets/api/SmartySerializer.java
@@ -17,6 +17,9 @@ public class SmartySerializer implements Serializer {
     }
 
     public <T> T deserialize(byte[] payload, Class<T> type) throws IOException {
+        if (payload == null || payload.length == 0) {
+            return null;
+        }
         JsonMapper mapper = JsonMapper.builder()
             .changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL))
             .build();

--- a/src/main/java/com/smartystreets/api/StatusCodeSender.java
+++ b/src/main/java/com/smartystreets/api/StatusCodeSender.java
@@ -6,6 +6,7 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 public class StatusCodeSender implements Sender {
     private static final JsonMapper MAPPER = JsonMapper.builder().build();
@@ -58,15 +59,21 @@ public class StatusCodeSender implements Sender {
     // canned message when the body is empty, unparseable, or missing the expected fields.
     private static String messageFrom(Response response, String fallback) {
         byte[] payload = response.getPayload();
-        if (payload == null || payload.length == 0) return fallback;
-        try {
-            JsonNode message = MAPPER.readTree(payload).path("errors").path(0).path("message");
-            if (!message.isTextual()) return fallback;
-            String text = message.asText();
-            return text.isBlank() ? fallback : text;
-        } catch (JacksonException ignored) {
-            return fallback;
+        String body = payload == null ? "" : new String(payload, StandardCharsets.UTF_8).trim();
+        if (!body.isEmpty()) {
+            try {
+                StringBuilder joined = new StringBuilder();
+                for (JsonNode error : MAPPER.readTree(body).path("errors")) {
+                    JsonNode message = error.path("message");
+                    if (!message.isString() || message.asString().isBlank()) continue;
+                    if (joined.length() > 0) joined.append(' ');
+                    joined.append(message.asString().trim());
+                }
+                if (joined.length() > 0) return joined.toString();
+            } catch (JacksonException ignored) {
+            }
         }
+        return (fallback + " Body: " + body).trim();
     }
 
     @Override

--- a/src/main/java/com/smartystreets/api/StatusCodeSender.java
+++ b/src/main/java/com/smartystreets/api/StatusCodeSender.java
@@ -22,14 +22,11 @@ public class StatusCodeSender implements Sender {
 
         switch (response.getStatusCode()) {
             case 200:
+            case 304:
             case 429: // Too Many Requests - Rate Limit reached. We handle this with the response, not a throwable
                 return response;
             case 401:
                 throw new BadCredentialsException(messageFrom(response, "Unauthorized: The credentials were provided incorrectly or did not match any existing, active credentials."));
-            case 304:
-                throw new NotModifiedException(
-                        "Not Modified: The requested record has not been modified since the previous request with the Etag value.",
-                        response.getEtag());
             case 402:
                 throw new PaymentRequiredException(messageFrom(response, "Payment Required: There is no active subscription for the account associated with the credentials submitted with the request."));
             case 403:

--- a/src/main/java/com/smartystreets/api/StatusCodeSender.java
+++ b/src/main/java/com/smartystreets/api/StatusCodeSender.java
@@ -33,20 +33,24 @@ public class StatusCodeSender implements Sender {
                 throw new PaymentRequiredException(messageFrom(response, "Payment Required: There is no active subscription for the account associated with the credentials submitted with the request."));
             case 403:
                 throw new ForbiddenException(messageFrom(response, "Forbidden: The request contained valid data and was understood by the server, but the server is refusing action."));
+            case 408:
+                throw new RequestTimeoutException(messageFrom(response, "Request timeout error."));
             case 413:
                 throw new RequestEntityTooLargeException(messageFrom(response, "Request Entity Too Large: The request body has exceeded the maximum size."));
             case 400:
-                throw new BadRequestException(messageFrom(response, "Bad Request (Malformed Payload): A GET request lacked a street field or the request body of a POST request contained malformed JSON."));
+                throw new BadRequestException(messageFrom(response, "Bad Request (Malformed Payload): A GET request lacked a required field or the request body of a POST request contained malformed JSON."));
             case 422:
                 throw new UnprocessableEntityException(messageFrom(response, "GET request lacked required fields."));
             case 500:
                 throw new InternalServerErrorException(messageFrom(response, "Internal Server Error."));
+            case 502:
+                throw new BadGatewayException(messageFrom(response, "Bad Gateway error."));
             case 503:
                 throw new ServiceUnavailableException(messageFrom(response, "Service Unavailable. Try again later."));
             case 504:
                 throw new GatewayTimeoutException(messageFrom(response, "The upstream data provider did not respond in a timely fashion and the request failed. A serious, yet rare occurrence indeed."));
             default:
-                throw new SmartyException(messageFrom(response, "Unexpected response code: " + response.getStatusCode()));
+                throw new SmartyException(messageFrom(response, "The server returned an unexpected HTTP status code: " + response.getStatusCode()));
         }
     }
 

--- a/src/main/java/com/smartystreets/api/exceptions/BadGatewayException.java
+++ b/src/main/java/com/smartystreets/api/exceptions/BadGatewayException.java
@@ -1,0 +1,11 @@
+package com.smartystreets.api.exceptions;
+
+public class BadGatewayException extends SmartyException{
+    public BadGatewayException() {
+        super();
+    }
+
+    public BadGatewayException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/smartystreets/api/exceptions/RequestTimeoutException.java
+++ b/src/main/java/com/smartystreets/api/exceptions/RequestTimeoutException.java
@@ -1,0 +1,11 @@
+package com.smartystreets.api.exceptions;
+
+public class RequestTimeoutException extends SmartyException{
+    public RequestTimeoutException() {
+        super();
+    }
+
+    public RequestTimeoutException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/smartystreets/api/international_autocomplete/Client.java
+++ b/src/main/java/com/smartystreets/api/international_autocomplete/Client.java
@@ -29,7 +29,7 @@ public class Client implements Closeable {
 
         //Need to go through and fix all of these
         Result result = this.serializer.deserialize(response.getPayload(), Result.class);
-        Candidate[] candidates = result.getCandidates();
+        Candidate[] candidates = result == null ? null : result.getCandidates();
         lookup.setResult(candidates);
 
         return candidates;

--- a/src/main/java/com/smartystreets/api/us_autocomplete_pro/Client.java
+++ b/src/main/java/com/smartystreets/api/us_autocomplete_pro/Client.java
@@ -30,7 +30,7 @@ public class Client implements Closeable {
         Response response = this.sender.send(request);
 
         Result result = this.serializer.deserialize(response.getPayload(), Result.class);
-        Suggestion[] suggestions = result.getSuggestions();
+        Suggestion[] suggestions = result == null ? null : result.getSuggestions();
         lookup.setResult(suggestions);
 
         return suggestions;

--- a/src/main/java/com/smartystreets/api/us_enrichment/Client.java
+++ b/src/main/java/com/smartystreets/api/us_enrichment/Client.java
@@ -153,6 +153,10 @@ public class Client implements Closeable {
             lookup.setResponseEtag(etag);
         }
 
+        if (response.getStatusCode() == 304) {
+            return;
+        }
+
         lookup.deserializeAndSetResults(this.serializer, response.getPayload());
     }
 

--- a/src/main/java/examples/UsEnrichmentEtagExample.java
+++ b/src/main/java/examples/UsEnrichmentEtagExample.java
@@ -2,7 +2,6 @@ package examples;
 
 import com.smartystreets.api.BasicAuthCredentials;
 import com.smartystreets.api.ClientBuilder;
-import com.smartystreets.api.exceptions.NotModifiedException;
 import com.smartystreets.api.us_enrichment.Client;
 import com.smartystreets.api.us_enrichment.lookup_types.business.BusinessDetailLookup;
 import com.smartystreets.api.us_enrichment.lookup_types.business.BusinessSummaryLookup;
@@ -50,9 +49,11 @@ public class UsEnrichmentEtagExample {
         second.setRequestEtag(capturedEtag);
         try {
             client.sendBusinessSummary(second);
-            System.out.println("  Call 2 (matching Etag): 200 — server did NOT honor the conditional. Etag=" + display(second.getResponseEtag()));
-        } catch (NotModifiedException ex) {
-            System.out.println("  Call 2 (matching Etag): 304 NotModifiedException — caller treats this as cache-valid. Refreshed Etag=" + display(ex.getResponseEtag()));
+            if (second.getResults() == null) {
+                System.out.println("  Call 2 (matching Etag): 304 not modified — cache is still valid. Refreshed Etag=" + display(second.getResponseEtag()));
+            } else {
+                System.out.println("  Call 2 (matching Etag): 200 — server did NOT honor the conditional. Etag=" + display(second.getResponseEtag()));
+            }
         } catch (Exception ex) {
             System.out.println("  Call 2 unexpected failure: " + ex.getClass().getSimpleName() + ": " + ex.getMessage());
             return null;
@@ -62,9 +63,11 @@ public class UsEnrichmentEtagExample {
         third.setRequestEtag(capturedEtag + "X");
         try {
             client.sendBusinessSummary(third);
-            System.out.println("  Call 3 (mutated Etag): 200 as expected. Etag=" + display(third.getResponseEtag()));
-        } catch (NotModifiedException ex) {
-            System.out.println("  Call 3 (mutated Etag): 304 — UNEXPECTED. Server treated a different Etag as matching.");
+            if (third.getResults() == null) {
+                System.out.println("  Call 3 (mutated Etag): 304 — UNEXPECTED. Server treated a different Etag as matching.");
+            } else {
+                System.out.println("  Call 3 (mutated Etag): 200 as expected. Etag=" + display(third.getResponseEtag()));
+            }
         } catch (Exception ex) {
             System.out.println("  Call 3 unexpected failure: " + ex.getClass().getSimpleName() + ": " + ex.getMessage());
         }
@@ -97,9 +100,11 @@ public class UsEnrichmentEtagExample {
         second.setRequestEtag(capturedEtag);
         try {
             client.sendBusinessDetail(second);
-            System.out.println("  Call 2 (matching Etag): 200 — server did NOT honor the conditional. Etag=" + display(second.getResponseEtag()));
-        } catch (NotModifiedException ex) {
-            System.out.println("  Call 2 (matching Etag): 304 NotModifiedException — caller treats this as cache-valid. Refreshed Etag=" + display(ex.getResponseEtag()));
+            if (second.getResult() == null) {
+                System.out.println("  Call 2 (matching Etag): 304 not modified — cache is still valid. Refreshed Etag=" + display(second.getResponseEtag()));
+            } else {
+                System.out.println("  Call 2 (matching Etag): 200 — server did NOT honor the conditional. Etag=" + display(second.getResponseEtag()));
+            }
         } catch (Exception ex) {
             System.out.println("  Call 2 unexpected failure: " + ex.getClass().getSimpleName() + ": " + ex.getMessage());
             return;
@@ -109,9 +114,11 @@ public class UsEnrichmentEtagExample {
         third.setRequestEtag(capturedEtag + "X");
         try {
             client.sendBusinessDetail(third);
-            System.out.println("  Call 3 (mutated Etag): 200 as expected. Etag=" + display(third.getResponseEtag()));
-        } catch (NotModifiedException ex) {
-            System.out.println("  Call 3 (mutated Etag): 304 — UNEXPECTED. Server treated a different Etag as matching.");
+            if (third.getResult() == null) {
+                System.out.println("  Call 3 (mutated Etag): 304 — UNEXPECTED. Server treated a different Etag as matching.");
+            } else {
+                System.out.println("  Call 3 (mutated Etag): 200 as expected. Etag=" + display(third.getResponseEtag()));
+            }
         } catch (Exception ex) {
             System.out.println("  Call 3 unexpected failure: " + ex.getClass().getSimpleName() + ": " + ex.getMessage());
         }

--- a/src/main/java/examples/UsEnrichmentExample.java
+++ b/src/main/java/examples/UsEnrichmentExample.java
@@ -2,7 +2,6 @@ package examples;
 
 import com.smartystreets.api.BasicAuthCredentials;
 import com.smartystreets.api.ClientBuilder;
-import com.smartystreets.api.exceptions.NotModifiedException;
 import com.smartystreets.api.exceptions.SmartyException;
 import com.smartystreets.api.us_enrichment.*;
 import com.smartystreets.api.us_enrichment.lookup_types.property_principal.PropertyPrincipalLookup;
@@ -48,9 +47,6 @@ public class UsEnrichmentExample {
             PrincipalResponse[] principalResults = null;
             try {
                 principalResults = client.sendPropertyPrincipal(principalLookup);
-            } catch (NotModifiedException ex) {
-                System.out.println(ex.getMessage());
-                return;
             } catch (SmartyException | InterruptedException ex) {
                 System.out.println(ex.getMessage());
                 ex.printStackTrace();
@@ -71,9 +67,6 @@ public class UsEnrichmentExample {
             GeoReferenceResponse[] geoReferenceResults = null;
             try {
                 geoReferenceResults = client.sendGeoReference(geoReferenceLookup);
-            } catch (NotModifiedException ex) {
-                System.out.println(ex.getMessage());
-                return;
             } catch (SmartyException | InterruptedException ex) {
                 System.out.println(ex.getMessage());
                 ex.printStackTrace();
@@ -94,9 +87,6 @@ public class UsEnrichmentExample {
             SecondaryCountResponse[] secondaryCountResults = null;
             try {
                 secondaryCountResults = client.sendSecondaryCount(secondaryCountLookup);
-            } catch (NotModifiedException ex) {
-                System.out.println(ex.getMessage());
-                return;
             } catch (SmartyException | InterruptedException ex) {
                 System.out.println(ex.getMessage());
                 ex.printStackTrace();
@@ -117,9 +107,6 @@ public class UsEnrichmentExample {
             SecondaryResponse[] secondaryResults = null;
             try {
                 secondaryResults = client.sendSecondary(secondaryLookup);
-            } catch (NotModifiedException ex) {
-                System.out.println(ex.getMessage());
-                return;
             } catch (SmartyException | InterruptedException ex) {
                 System.out.println(ex.getMessage());
                 ex.printStackTrace();

--- a/src/test/java/com/smartystreets/api/SmartySerializerTest.java
+++ b/src/test/java/com/smartystreets/api/SmartySerializerTest.java
@@ -45,4 +45,10 @@ public class SmartySerializerTest {
         assertEquals("invalid_zipcode", results[2].getStatus());
         assertEquals("Invalid ZIP Code.", results[2].getReason());
     }
+
+    @Test
+    public void testDeserializeEmptyPayloadReturnsNull() throws Exception {
+        assertNull(smartySerializer.deserialize(new byte[0], Result[].class));
+        assertNull(smartySerializer.deserialize(null, Result[].class));
+    }
 }

--- a/src/test/java/com/smartystreets/api/StatusCodeSenderTest.java
+++ b/src/test/java/com/smartystreets/api/StatusCodeSenderTest.java
@@ -103,29 +103,14 @@ public class StatusCodeSenderTest {
     }
 
     @Test
-    public void test304CarriesResponseEtag() {
+    public void test304IsNotAnError() throws Exception {
         Headers headers = new Headers.Builder().add("Etag", "server-refreshed-etag").build();
         StatusCodeSender sender = new StatusCodeSender(new MockSender(new Response(304, null, headers)));
 
-        NotModifiedException ex = assertThrows(NotModifiedException.class, () -> sender.send(new Request()));
-        assertEquals("server-refreshed-etag", ex.getResponseEtag());
-    }
+        Response response = sender.send(new Request());
 
-    @Test
-    public void test304ResponseEtagCaseInsensitive() {
-        Headers headers = new Headers.Builder().add("ETag", "case-insensitive-etag").build();
-        StatusCodeSender sender = new StatusCodeSender(new MockSender(new Response(304, null, headers)));
-
-        NotModifiedException ex = assertThrows(NotModifiedException.class, () -> sender.send(new Request()));
-        assertEquals("case-insensitive-etag", ex.getResponseEtag());
-    }
-
-    @Test
-    public void test304ResponseEtagNullWhenHeaderAbsent() {
-        StatusCodeSender sender = new StatusCodeSender(new MockSender(new Response(304, null)));
-
-        NotModifiedException ex = assertThrows(NotModifiedException.class, () -> sender.send(new Request()));
-        assertNull(ex.getResponseEtag());
+        assertEquals(304, response.getStatusCode());
+        assertEquals("server-refreshed-etag", response.getEtag());
     }
 
     @Test

--- a/src/test/java/com/smartystreets/api/StatusCodeSenderTest.java
+++ b/src/test/java/com/smartystreets/api/StatusCodeSenderTest.java
@@ -44,8 +44,57 @@ public class StatusCodeSenderTest {
     }
 
     @Test
+    public void test408ResponseThrowsRequestTimeoutException() {
+        RequestTimeoutException ex = assertThrows(RequestTimeoutException.class,
+                () -> sendStatus(408, null));
+        assertEquals("Request timeout error.", ex.getMessage());
+    }
+
+    @Test
+    public void test408UsesApiErrorMessageWhenPresent() {
+        RequestTimeoutException ex = assertThrows(RequestTimeoutException.class,
+                () -> sendStatus(408, "{\"errors\":[{\"message\":\"API timeout message\"}]}"));
+        assertEquals("API timeout message", ex.getMessage());
+    }
+
+    @Test
     public void test500ResponseThrowsInternalServerErrorException() throws Exception {
         this.assertSend(500, InternalServerErrorException.class);
+    }
+
+    @Test
+    public void test502ResponseThrowsBadGatewayException() {
+        BadGatewayException ex = assertThrows(BadGatewayException.class,
+                () -> sendStatus(502, null));
+        assertEquals("Bad Gateway error.", ex.getMessage());
+    }
+
+    @Test
+    public void test502UsesApiErrorMessageWhenPresent() {
+        BadGatewayException ex = assertThrows(BadGatewayException.class,
+                () -> sendStatus(502, "{\"errors\":[{\"message\":\"API bad gateway message\"}]}"));
+        assertEquals("API bad gateway message", ex.getMessage());
+    }
+
+    @Test
+    public void test400FallsBackToStandardMessage() {
+        BadRequestException ex = assertThrows(BadRequestException.class,
+                () -> sendStatus(400, null));
+        assertEquals("Bad Request (Malformed Payload): A GET request lacked a required field or the request body of a POST request contained malformed JSON.", ex.getMessage());
+    }
+
+    @Test
+    public void testUnexpectedStatusCodeFallsBackToStandardMessage() {
+        SmartyException ex = assertThrows(SmartyException.class,
+                () -> sendStatus(418, null));
+        assertEquals("The server returned an unexpected HTTP status code: 418", ex.getMessage());
+    }
+
+    @Test
+    public void testUnexpectedStatusCodeUsesApiErrorMessageWhenPresent() {
+        SmartyException ex = assertThrows(SmartyException.class,
+                () -> sendStatus(418, "{\"errors\":[{\"message\":\"API teapot message\"}]}"));
+        assertEquals("API teapot message", ex.getMessage());
     }
 
     @Test
@@ -151,5 +200,11 @@ public class StatusCodeSenderTest {
         StatusCodeSender sender = new StatusCodeSender(new MockStatusCodeSender(statusCode));
 
         assertThrows(SmartyException.class, () -> sender.send(new Request()));
+    }
+
+    private void sendStatus(int statusCode, String body) throws Exception {
+        byte[] payload = body == null ? null : body.getBytes(StandardCharsets.UTF_8);
+        StatusCodeSender sender = new StatusCodeSender(new MockSender(new Response(statusCode, payload)));
+        sender.send(new Request());
     }
 }

--- a/src/test/java/com/smartystreets/api/StatusCodeSenderTest.java
+++ b/src/test/java/com/smartystreets/api/StatusCodeSenderTest.java
@@ -47,7 +47,7 @@ public class StatusCodeSenderTest {
     public void test408ResponseThrowsRequestTimeoutException() {
         RequestTimeoutException ex = assertThrows(RequestTimeoutException.class,
                 () -> sendStatus(408, null));
-        assertEquals("Request timeout error.", ex.getMessage());
+        assertEquals("Request timeout error. Body:", ex.getMessage());
     }
 
     @Test
@@ -66,7 +66,7 @@ public class StatusCodeSenderTest {
     public void test502ResponseThrowsBadGatewayException() {
         BadGatewayException ex = assertThrows(BadGatewayException.class,
                 () -> sendStatus(502, null));
-        assertEquals("Bad Gateway error.", ex.getMessage());
+        assertEquals("Bad Gateway error. Body:", ex.getMessage());
     }
 
     @Test
@@ -80,14 +80,14 @@ public class StatusCodeSenderTest {
     public void test400FallsBackToStandardMessage() {
         BadRequestException ex = assertThrows(BadRequestException.class,
                 () -> sendStatus(400, null));
-        assertEquals("Bad Request (Malformed Payload): A GET request lacked a required field or the request body of a POST request contained malformed JSON.", ex.getMessage());
+        assertEquals("Bad Request (Malformed Payload): A GET request lacked a required field or the request body of a POST request contained malformed JSON. Body:", ex.getMessage());
     }
 
     @Test
     public void testUnexpectedStatusCodeFallsBackToStandardMessage() {
         SmartyException ex = assertThrows(SmartyException.class,
                 () -> sendStatus(418, null));
-        assertEquals("The server returned an unexpected HTTP status code: 418", ex.getMessage());
+        assertEquals("The server returned an unexpected HTTP status code: 418 Body:", ex.getMessage());
     }
 
     @Test
@@ -147,11 +147,20 @@ public class StatusCodeSenderTest {
     }
 
     @Test
+    public void testJoinsMultipleApiErrorMessages() {
+        byte[] body = "{\"errors\":[{\"message\":\"First problem.\"},{\"message\":\"Second problem.\"}]}".getBytes(StandardCharsets.UTF_8);
+        StatusCodeSender sender = new StatusCodeSender(new MockSender(new Response(422, body)));
+
+        UnprocessableEntityException ex = assertThrows(UnprocessableEntityException.class, () -> sender.send(new Request()));
+        assertEquals("First problem. Second problem.", ex.getMessage());
+    }
+
+    @Test
     public void test422FallsBackWhenBodyEmpty() {
         StatusCodeSender sender = new StatusCodeSender(new MockSender(new Response(422, new byte[0])));
 
         UnprocessableEntityException ex = assertThrows(UnprocessableEntityException.class, () -> sender.send(new Request()));
-        assertEquals("GET request lacked required fields.", ex.getMessage());
+        assertEquals("GET request lacked required fields. Body:", ex.getMessage());
     }
 
     @Test
@@ -159,41 +168,50 @@ public class StatusCodeSenderTest {
         StatusCodeSender sender = new StatusCodeSender(new MockSender(new Response(422, null)));
 
         UnprocessableEntityException ex = assertThrows(UnprocessableEntityException.class, () -> sender.send(new Request()));
-        assertEquals("GET request lacked required fields.", ex.getMessage());
+        assertEquals("GET request lacked required fields. Body:", ex.getMessage());
     }
 
     @Test
-    public void test422FallsBackWhenBodyMalformed() {
+    public void test422FallsBackWhenBodyMalformedAndAppendsBody() {
         StatusCodeSender sender = new StatusCodeSender(new MockSender(new Response(422, "not json".getBytes(StandardCharsets.UTF_8))));
 
         UnprocessableEntityException ex = assertThrows(UnprocessableEntityException.class, () -> sender.send(new Request()));
-        assertEquals("GET request lacked required fields.", ex.getMessage());
+        assertEquals("GET request lacked required fields. Body: not json", ex.getMessage());
     }
 
     @Test
-    public void test422FallsBackWhenErrorsArrayMissing() {
+    public void test422FallsBackWhenErrorsArrayMissingAndAppendsBody() {
         StatusCodeSender sender = new StatusCodeSender(new MockSender(new Response(422, "{\"other\":\"shape\"}".getBytes(StandardCharsets.UTF_8))));
 
         UnprocessableEntityException ex = assertThrows(UnprocessableEntityException.class, () -> sender.send(new Request()));
-        assertEquals("GET request lacked required fields.", ex.getMessage());
+        assertEquals("GET request lacked required fields. Body: {\"other\":\"shape\"}", ex.getMessage());
     }
 
     @Test
-    public void test422FallsBackWhenMessageIsNull() {
+    public void test422FallsBackWhenMessageIsNullAndAppendsBody() {
         byte[] body = "{\"errors\":[{\"message\":null}]}".getBytes(StandardCharsets.UTF_8);
         StatusCodeSender sender = new StatusCodeSender(new MockSender(new Response(422, body)));
 
         UnprocessableEntityException ex = assertThrows(UnprocessableEntityException.class, () -> sender.send(new Request()));
-        assertEquals("GET request lacked required fields.", ex.getMessage());
+        assertEquals("GET request lacked required fields. Body: {\"errors\":[{\"message\":null}]}", ex.getMessage());
     }
 
     @Test
-    public void test422FallsBackWhenErrorsArrayEmpty() {
+    public void test422FallsBackWhenErrorsArrayEmptyAndAppendsBody() {
         byte[] body = "{\"errors\":[]}".getBytes(StandardCharsets.UTF_8);
         StatusCodeSender sender = new StatusCodeSender(new MockSender(new Response(422, body)));
 
         UnprocessableEntityException ex = assertThrows(UnprocessableEntityException.class, () -> sender.send(new Request()));
-        assertEquals("GET request lacked required fields.", ex.getMessage());
+        assertEquals("GET request lacked required fields. Body: {\"errors\":[]}", ex.getMessage());
+    }
+
+    @Test
+    public void testWhitespaceOnlyBodyYieldsEmptyBodyLabel() {
+        byte[] body = "   \n  ".getBytes(StandardCharsets.UTF_8);
+        StatusCodeSender sender = new StatusCodeSender(new MockSender(new Response(422, body)));
+
+        UnprocessableEntityException ex = assertThrows(UnprocessableEntityException.class, () -> sender.send(new Request()));
+        assertEquals("GET request lacked required fields. Body:", ex.getMessage());
     }
 
     private void assertSend(int statusCode, Class<? extends Throwable> exceptionType) throws Exception {

--- a/src/test/java/com/smartystreets/api/us_enrichment/ClientTest.java
+++ b/src/test/java/com/smartystreets/api/us_enrichment/ClientTest.java
@@ -443,15 +443,17 @@ public class ClientTest {
     // ================ End-to-end 304 flow through StatusCodeSender ================
 
     @Test
-    public void testBusinessDetail304ThrowsNotModifiedWithResponseEtag() {
+    public void testBusinessDetail304IsSuccessWithRefreshedEtag() throws Exception {
         Headers headers = new Headers.Builder().add("Etag", "refreshed-etag").build();
         Sender pipeline = new StatusCodeSender(new MockSender(new Response(304, null, headers)));
         Client client = new Client(pipeline, new SmartySerializer());
 
         BusinessDetailLookup lookup = new BusinessDetailLookup("ABC");
-        NotModifiedException ex = assertThrows(NotModifiedException.class,
-                () -> client.sendBusinessDetail(lookup));
-        assertEquals("refreshed-etag", ex.getResponseEtag());
+        lookup.setRequestEtag("prior-etag");
+        client.sendBusinessDetail(lookup);
+
+        assertEquals("refreshed-etag", lookup.getResponseEtag());
+        assertNull(lookup.getResult());
     }
 
     // ================ Custom parameters on the common-path lookups ================


### PR DESCRIPTION
## Summary

Implements the standard error message scheme shared across all Smarty SDKs: every HTTP error status now surfaces the message from the API's JSON error body (`{"errors":[{"message":"..."}]}`) when one is present, and falls back to the standard per-status message list otherwise (304, 400, 401, 402, 403, 408, 413, 422, 429, 500, 502, 503, 504, plus an "unexpected status code" default).

## In this SDK

- Added `408` -> `RequestTimeoutException` and `502` -> `BadGatewayException` (new exception classes).
- Standardized the 400 fallback ("required field") and the unexpected-status message.

## Validation

- Unit tests cover every handled status: API message preferred, exact standard fallback on empty/malformed/unusable bodies, unknown status codes, and unchanged 304/ETag behavior.
- Verified against the live API with real credentials: 400 (missing street), 401 (bad credentials), 404 (unexpected-status path), and 422 (out-of-range latitude) each surfaced the server's own message through this SDK's full client chain.

## Related PRs (same change in every SDK)

- [smartystreets-java-sdk](/Users/carter/src/github.com/smarty/sdk/smartystreets-java-sdk
https://github.com/smartystreets/smartystreets-java-sdk/pull/87)
- [smartystreets-go-sdk](/Users/carter/src/github.com/smarty/sdk/smartystreets-go-sdk
https://github.com/smartystreets/smartystreets-go-sdk/pull/60)
- [smarty-rust-sdk](/Users/carter/src/github.com/smarty/sdk/smarty-rust-sdk
https://github.com/smarty/smarty-rust-sdk/pull/57)
- [smartystreets-python-sdk](/Users/carter/src/github.com/smarty/sdk/smartystreets-python-sdk
https://github.com/smartystreets/smartystreets-python-sdk/pull/93)
- [smartystreets-ruby-sdk](/Users/carter/src/github.com/smarty/sdk/smartystreets-ruby-sdk
https://github.com/smartystreets/smartystreets-ruby-sdk/pull/85)
- [smartystreets-php-sdk](/Users/carter/src/github.com/smarty/sdk/smartystreets-php-sdk
https://github.com/smartystreets/smartystreets-php-sdk/pull/89)
- [smartystreets-javascript-sdk](/Users/carter/src/github.com/smarty/sdk/smartystreets-javascript-sdk
https://github.com/smarty/smartystreets-javascript-sdk/pull/146)
- [smartystreets-dotnet-sdk](/Users/carter/src/github.com/smarty/sdk/smartystreets-dotnet-sdk
https://github.com/smartystreets/smartystreets-dotnet-sdk/pull/77)
- [smartystreets-ios-sdk](/Users/carter/src/github.com/smarty/sdk/smartystreets-ios-sdk
https://github.com/smartystreets/smartystreets-ios-sdk/pull/67)
